### PR TITLE
fix typo 8.2

### DIFF
--- a/02_07_Funktionen_in_DataFrames.ipynb
+++ b/02_07_Funktionen_in_DataFrames.ipynb
@@ -462,7 +462,7 @@
     "\n",
     "`pandas` kennt eine ganze Familie von Methoden, um Spalten zu Manipulieren und Daten zu Aggregiren (`apply`, `map`, `mapapply`, `assign`). Es würde den Rahmen von diesem Kurs sprengen, die alle im Detail durch zu gehen, es lohnt sich aber sehr sich mit diesen zu befassen wenn man in sich näher mit Python befassen möchte.\n",
     "\n",
-    "Im unseren Fall brauchen wir lediglich die Methode `apply` um die Funktion `offset_coordiante()` auf die Zeckenstichkoordinaten anzuwenden. Dabei gehen wir wie folgt for:\n"
+    "Im unseren Fall brauchen wir lediglich die Methode `apply` um die Funktion `offset_coordinate()` auf die Zeckenstichkoordinaten anzuwenden. Dabei gehen wir wie folgt for:\n"
    ]
   },
   {
@@ -1206,7 +1206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
fixing typo "coordinate" -- in Übung 8.2